### PR TITLE
refactor: remove LaunchTube support from SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- LaunchTube support removed from `send()` method and `SendRequest` interface
+- `launchtube` parameter removed from `send()` — signature is now `send(xdr, network?)`
+- `'launchtube'` removed from `submissionMethod` union type
+
 ### Added
 
 #### Balances Methods

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ The SDK accepts configuration including:
 - `apiKey` - API key for authentication (must start with 'sk_')
 - `baseUrl` - Custom API base URL (optional, defaults to 'https://api.soroswap.finance')
 - `defaultNetwork` - MAINNET or TESTNET
-- `timeout` - Request timeout (default 30s, consider increasing for launchtube)
+- `timeout` - Request timeout (default 30s)
 
 ## Build Configuration
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const buildResponse = await soroswapClient.build({
 const signedXdr = await yourSigner.sign(buildResponse.xdr);
 
 // Send the signed transaction
-const result = await soroswapClient.send(signedXdr, false); // launchtube = false
+const result = await soroswapClient.send(signedXdr);
 console.log('Transaction result:', result);
 ```
 
@@ -65,7 +65,7 @@ interface SoroswapSDKConfig {
   apiKey: string;                   // Your Soroswap API key (starts with 'sk_')
   baseUrl?: string;                 // Custom API base URL (defaults to 'https://api.soroswap.finance')
   defaultNetwork?: SupportedNetworks;  // SupportedNetworks.MAINNET | SupportedNetworks.TESTNET
-  timeout?: number;                // Request timeout in ms (defaults to 30000) you might want to adjust this if using launchtube
+  timeout?: number;                // Request timeout in ms (defaults to 30000)
 }
 ```
 
@@ -146,9 +146,8 @@ const buildResponse = await soroswapClient.build({
 
 ```typescript
 const result = await soroswapClient.send(
-  signedXdr,           // The signed transaction XDR
-  false,               // launchtube: boolean (default false)
-  SupportedNetworks.MAINNET  // Optional network override
+  signedXdr,                        // The signed transaction XDR
+  SupportedNetworks.MAINNET         // Optional network override
 );
 ```
 

--- a/examples/backend-example.js
+++ b/examples/backend-example.js
@@ -81,7 +81,7 @@ async function main() {
     // Example of sending (commented out as it requires a signed XDR):
     /*
     const signedXdr = 'YOUR_SIGNED_XDR_HERE';
-    const sendResult = await sdk.send(signedXdr, false); // launchtube = false
+    const sendResult = await sdk.send(signedXdr);
     console.log('Transaction sent:', sendResult);
     */
 
@@ -170,9 +170,9 @@ function createExpressEndpoints(app) {
   // Endpoint to send signed transaction
   app.post('/api/send-transaction', async (req, res) => {
     try {
-      const { signedXdr, launchtube = false } = req.body;
+      const { signedXdr } = req.body;
 
-      const result = await sdk.send(signedXdr, launchtube);
+      const result = await sdk.send(signedXdr);
 
       res.json({
         success: true,

--- a/llms.txt
+++ b/llms.txt
@@ -94,11 +94,10 @@ interface SoroswapSDKConfig {
 - **Returns**: `BuildQuoteResponse` - Contains XDR string
 
 #### Send Transaction
-- **Method**: `send(xdr: string, launchtube: boolean = false, network?: SupportedNetworks)`
+- **Method**: `send(xdr: string, network?: SupportedNetworks)`
 - **Purpose**: Submit signed transaction to network
 - **Parameters**:
   - `xdr`: Signed transaction XDR string
-  - `launchtube`: Use launchtube for submission (optional)
   - `network`: Network override (optional)
 - **Returns**: Transaction result
 

--- a/soroswap-sdk-skill.md
+++ b/soroswap-sdk-skill.md
@@ -314,7 +314,7 @@ interface SendTransactionResponse {
   feeBump: boolean;
   feeCharged: string;               // In stroops
   protocol: "router" | "aggregator" | "sdex" | "unknown";
-  submissionMethod: "soroban" | "horizon" | "launchtube";
+  submissionMethod: "soroban" | "horizon";
 }
 
 // Type-safe result access:
@@ -337,7 +337,7 @@ if (result.result?.type === "swap") {
 |---|---|---|
 | Get quote | `quote(request, network?)` | No |
 | Build swap XDR | `build(request, network?)` | Yes |
-| Send signed TX | `send(xdr, launchtube?, network?)` | N/A |
+| Send signed TX | `send(xdr, network?)` | N/A |
 | Add liquidity | `addLiquidity(request, network?)` | Yes |
 | Remove liquidity | `removeLiquidity(request, network?)` | Yes |
 | User positions | `getUserPositions(address, network?)` | No |

--- a/src/soroswap-sdk.ts
+++ b/src/soroswap-sdk.ts
@@ -134,11 +134,11 @@ export class SoroswapSDK {
    * Send signed transaction
    * @returns Normalized transaction response with parsed result
    */
-  async send(xdr: string, launchtube: boolean = false, network?: SupportedNetworks): Promise<SendTransactionResponse> {
+  async send(xdr: string, network?: SupportedNetworks): Promise<SendTransactionResponse> {
     const params = { network: network || this.defaultNetwork };
     const url = this.httpClient.buildUrlWithQuery('/send', params);
 
-    const sendData: SendRequest = { xdr, launchtube };
+    const sendData: SendRequest = { xdr };
     return this.httpClient.post<SendTransactionResponse>(url, sendData);
   }
 

--- a/src/types/send.ts
+++ b/src/types/send.ts
@@ -4,7 +4,6 @@
 
 export interface SendRequest {
   xdr: string;
-  launchtube?: boolean;
 }
 
 // ============================================
@@ -92,5 +91,5 @@ export interface SendTransactionResponse {
   protocol: 'router' | 'aggregator' | 'sdex' | 'unknown';
 
   /** Transaction submission method */
-  submissionMethod: 'soroban' | 'horizon' | 'launchtube';
+  submissionMethod: 'soroban' | 'horizon';
 }

--- a/tests/soroswap-sdk.test.ts
+++ b/tests/soroswap-sdk.test.ts
@@ -286,7 +286,6 @@ describe('SoroswapSDK - Comprehensive Unit Tests', () => {
     it('should send transaction with default parameters', async () => {
       const expectedRequest: SendRequest = {
         xdr: 'SIGNED_XDR_123',
-        launchtube: false
       };
 
       mockHttpClient.post = jest.fn().mockResolvedValue(mockSendResponse);
@@ -297,29 +296,14 @@ describe('SoroswapSDK - Comprehensive Unit Tests', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith('/send?network=testnet', expectedRequest);
     });
 
-    it('should send transaction with launchtube enabled', async () => {
-      const expectedRequest: SendRequest = {
-        xdr: 'SIGNED_XDR_123',
-        launchtube: true
-      };
-
-      mockHttpClient.post = jest.fn().mockResolvedValue(mockSendResponse);
-
-      const result = await sdk.send('SIGNED_XDR_123', true);
-
-      expect(result).toEqual(mockSendResponse);
-      expect(mockHttpClient.post).toHaveBeenCalledWith('/send?network=testnet', expectedRequest);
-    });
-
     it('should send transaction with specified network', async () => {
       const expectedRequest: SendRequest = {
         xdr: 'SIGNED_XDR_123',
-        launchtube: false
       };
 
       mockHttpClient.post = jest.fn().mockResolvedValue(mockSendResponse);
 
-      const result = await sdk.send('SIGNED_XDR_123', false, SupportedNetworks.MAINNET);
+      const result = await sdk.send('SIGNED_XDR_123', SupportedNetworks.MAINNET);
 
       expect(result).toEqual(mockSendResponse);
       expect(mockHttpClient.post).toHaveBeenCalledWith('/send?network=mainnet', expectedRequest);


### PR DESCRIPTION
## Summary
- Remove `launchtube` parameter from `send()` — signature is now `send(xdr, network?)`
- Remove `launchtube?: boolean` from `SendRequest` interface
- Remove `'launchtube'` from `submissionMethod` union type
- Update README, CLAUDE.md, llms.txt, skill file, and backend example

## Test plan
- [x] `grep -ri launchtube` returns only CHANGELOG entries
- [x] `pnpm test` — 73 tests pass
- [ ] Verify SDK consumers compile without `launchtube` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * LaunchTube submission method support has been removed from the SDK.
  * The `send()` method signature has changed and no longer accepts the `launchtube` parameter.
  * Transaction response submission method now only supports 'soroban' or 'horizon' options.

* **Documentation**
  * Updated API documentation, examples, and guides to reflect the removal of LaunchTube support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->